### PR TITLE
fix: Fix gem name selector

### DIFF
--- a/contexts/gem/Makefile
+++ b/contexts/gem/Makefile
@@ -21,7 +21,7 @@ ifeq ($(shell git tag -l $(VERSION)),)
 endif
 
 $(base_path)/$(GEM_FILE):
-	@cd $(base_path) && gem build $(base_path)/$(APP).gemspec -o $(base_path)/$(GEM_FILE)
+	@cd $(base_path) && gem build $(APP).gemspec -o $(GEM_FILE)
 
 ## build: build gem
 build: $(base_path)/$(GEM_FILE)

--- a/contexts/gem/Makefile
+++ b/contexts/gem/Makefile
@@ -21,7 +21,7 @@ ifeq ($(shell git tag -l $(VERSION)),)
 endif
 
 $(base_path)/$(GEM_FILE):
-	@gem build $(base_path)/$(APP).gemspec
+	@cd $(base_path) && gem build $(base_path)/$(APP).gemspec -o $(base_path)/$(GEM_FILE)
 
 ## build: build gem
 build: $(base_path)/$(GEM_FILE)

--- a/contexts/gem/Makefile
+++ b/contexts/gem/Makefile
@@ -5,7 +5,7 @@
 .PHONY: tag build publish
 SHELL := /bin/bash
 
-APP = $(shell grep "name" $(base_path)/*.gemspec | sed -E 's/.* = "(.*)"/\1/')
+APP = $(shell grep "\.name" $(base_path)/*.gemspec | sed -E 's/.* = "(.*)"/\1/')
 VERSION = $(shell grep VERSION $(base_path)/lib/$(APP)/version.rb | sed -E 's/.* = "(.*)"/\1/')
 APP_VERSION = $(APP)-$(VERSION)
 GEM_FILE = $(APP_VERSION).gem


### PR DESCRIPTION
Avoid selecting the wrong name of the gem, for example, when you have the word `name` in some gem. Like this:

```ruby
Gem::Specification.new do |spec|
  spec.name        = "container_broker"

  ...
  spec.add_dependency "redis-namespace"
end
```